### PR TITLE
File upload validation

### DIFF
--- a/app/Resources/translations/validators.en.yml
+++ b/app/Resources/translations/validators.en.yml
@@ -61,8 +61,6 @@ organisation:
     not_numeric: Please enter a numeric value.
     not_positive: Please enter a value greater than {{ limit }}.
     not_more_than: Please enter a value not exceeding {{ limit }}.
-    image__too_large: Please choose an image smaller than 2MB.
-    image_not_valid: Please choose a valid image.
     exact: The value must be exactly {{ limit }} characters long.
     name:
         already_used: This name is already in use.
@@ -240,3 +238,6 @@ testimonial:
         submit: Send
     placeholder:
         to: Select a volunteer
+file:
+    image__too_large: Please choose an image smaller than 2MB.
+    image_not_valid: Please choose a valid image.

--- a/app/Resources/translations/validators.en.yml
+++ b/app/Resources/translations/validators.en.yml
@@ -61,6 +61,8 @@ organisation:
     not_numeric: Please enter a numeric value.
     not_positive: Please enter a value greater than {{ limit }}.
     not_more_than: Please enter a value not exceeding {{ limit }}.
+    image__too_large: Please choose an image smaller than 2MB.
+    image_not_valid: Please choose a valid image.
     exact: The value must be exactly {{ limit }} characters long.
     name:
         already_used: This name is already in use.

--- a/app/Resources/translations/validators.nl.yml
+++ b/app/Resources/translations/validators.nl.yml
@@ -61,8 +61,6 @@ organisation:
     not_numeric: Gelieve een numerieke waarde op te geven.
     not_positive: Gelieve een waarde hoger dan {{ limit }} in te geven.
     not_more_than: Gelieve niet meer dan {{ limit }} in te geven.
-    image__too_large: Gelieve een afbeelding te kiezen die kleiner is dan 2MB.
-    image_not_valid: Gelieve een geldige afbeelding te kiezen.
     exact: De waarde moet exact {{ limit }} tekens langs zijn.
     name:
         already_used: Deze naam is reeds in gebruik.
@@ -240,3 +238,6 @@ testimonial:
         submit: Verzenden
     placeholder:
         to: Selecteer een vrijwilliger
+file:
+    image__too_large: Gelieve een afbeelding te kiezen die kleiner is dan 2MB.
+    image_not_valid: Gelieve een geldige afbeelding te kiezen.

--- a/app/Resources/translations/validators.nl.yml
+++ b/app/Resources/translations/validators.nl.yml
@@ -61,6 +61,8 @@ organisation:
     not_numeric: Gelieve een numerieke waarde op te geven.
     not_positive: Gelieve een waarde hoger dan {{ limit }} in te geven.
     not_more_than: Gelieve niet meer dan {{ limit }} in te geven.
+    image__too_large: Gelieve een afbeelding te kiezen die kleiner is dan 2MB.
+    image_not_valid: Gelieve een geldige afbeelding te kiezen.
     exact: De waarde moet exact {{ limit }} tekens langs zijn.
     name:
         already_used: Deze naam is reeds in gebruik.

--- a/app/Resources/translations/views.en.yml
+++ b/app/Resources/translations/views.en.yml
@@ -35,7 +35,7 @@ general:
         deleteorg: Remove organisation
         admins: Admins
         away: revoke admin rights
-    validatoion:
+    validation:
         not_valid_image: Please upload a valid image.
         too_large: Please upload an image smaller than 2MB.
         invalid_input: 'You forgot a field, or entered an invalid value for one of the fields.  Please check the form en follow the instructions for the field(s) with an error message.'

--- a/app/Resources/translations/views.en.yml
+++ b/app/Resources/translations/views.en.yml
@@ -207,6 +207,9 @@ org:
         button: Receive alerts
         remove: stop alerts
         add: start alerts
+    file:
+        not_valid: Please upload a valid image.
+        too_large: Please upload an image smaller than 2MB.
 person:
     general:
         volunteer: volunteer

--- a/app/Resources/translations/views.en.yml
+++ b/app/Resources/translations/views.en.yml
@@ -35,9 +35,10 @@ general:
         deleteorg: Remove organisation
         admins: Admins
         away: revoke admin rights
-    file:
+    validatoion:
         not_valid_image: Please upload a valid image.
         too_large: Please upload an image smaller than 2MB.
+        invalid_input: 'You forgot a field, or entered an invalid value for one of the fields.  Please check the form en follow the instructions for the field(s) with an error message.'
 base:
     general:
         name: Roeselare Volunteers

--- a/app/Resources/translations/views.en.yml
+++ b/app/Resources/translations/views.en.yml
@@ -35,7 +35,9 @@ general:
         deleteorg: Remove organisation
         admins: Admins
         away: revoke admin rights
-
+    file:
+        not_valid_image: Please upload a valid image.
+        too_large: Please upload an image smaller than 2MB.
 base:
     general:
         name: Roeselare Volunteers
@@ -207,9 +209,6 @@ org:
         button: Receive alerts
         remove: stop alerts
         add: start alerts
-    file:
-        not_valid: Please upload a valid image.
-        too_large: Please upload an image smaller than 2MB.
 person:
     general:
         volunteer: volunteer

--- a/app/Resources/translations/views.nl.yml
+++ b/app/Resources/translations/views.nl.yml
@@ -35,6 +35,9 @@ general:
         deleteorg: Organisatie verwijderen
         admins: Beheerders
         away: ontneem admin rechten
+    file:
+        not_valid_image: Gelieve een geldige afbeelding te selecteren.
+        too_large: Gelieve een afbeelding te selecteren die kleiner is dan 2MB.
 base:
     general:
         name: Roeselare vrijwilligt
@@ -207,9 +210,6 @@ org:
         button: Ontvang meldingen
         remove: stop meldingen
         add: start meldingen
-    file:
-        not_valid: Gelieve een geldige afbeelding te selecteren.
-        too_large: Gelieve een afbeelding te selecteren die kleiner is dan 2MB.
 person:
     general:
         volunteer: vrijwilliger

--- a/app/Resources/translations/views.nl.yml
+++ b/app/Resources/translations/views.nl.yml
@@ -207,6 +207,9 @@ org:
         button: Ontvang meldingen
         remove: stop meldingen
         add: start meldingen
+    file:
+        not_valid: Gelieve een geldige afbeelding te selecteren.
+        too_large: Gelieve een afbeelding te selecteren die kleiner is dan 2MB.
 person:
     general:
         volunteer: vrijwilliger

--- a/app/Resources/translations/views.nl.yml
+++ b/app/Resources/translations/views.nl.yml
@@ -35,9 +35,10 @@ general:
         deleteorg: Organisatie verwijderen
         admins: Beheerders
         away: ontneem admin rechten
-    file:
+    validation:
         not_valid_image: Gelieve een geldige afbeelding te selecteren.
         too_large: Gelieve een afbeelding te selecteren die kleiner is dan 2MB.
+        invalid_input: 'U vergat een veld of gaf een foutieve waarde in voor één van de velden.  Gelieve het formulier na te kijken en de instructies bij het veld / de velden waar de foutmelding staat de nodige stappen te ondernemen.'
 base:
     general:
         name: Roeselare vrijwilligt

--- a/app/Resources/views/organisation/maakvereniging.html.twig
+++ b/app/Resources/views/organisation/maakvereniging.html.twig
@@ -41,5 +41,6 @@
     <script src="{{ asset('js/livemap.js') }}"></script>
     <script src="{{ asset("js/forms.js") }}"></script>
     <script src="{{ asset("js/addadmin.js") }}"></script>
+    <script src="{{ asset("js/upload.js") }}"></script>
 {% endblock %}
 

--- a/app/Resources/views/organisation/maakvereniging.html.twig
+++ b/app/Resources/views/organisation/maakvereniging.html.twig
@@ -37,14 +37,6 @@
 
 {% block javascripts %}
     {{ parent() }}
-
-    <script>
-        var translations = {
-            "not_valid" : "{{ "org.file.not_valid"|trans }}",
-            "too_large" : "{{ "org.file.too_large"|trans }}"
-        }
-    </script>
-
     <script src="https://maps.googleapis.com/maps/api/js?key={{ googlemaps_key }}"></script>
     <script src="{{ asset('js/livemap.js') }}"></script>
     <script src="{{ asset("js/forms.js") }}"></script>

--- a/app/Resources/views/organisation/maakvereniging.html.twig
+++ b/app/Resources/views/organisation/maakvereniging.html.twig
@@ -37,6 +37,13 @@
 
 {% block javascripts %}
     {{ parent() }}
+    <script>
+        var translations = {
+            "not_valid" : "{{ "general.validation.not_valid_image"|trans }}",
+            "too_large" : "{{ "general.validation.too_large"|trans }}",
+            "invalid_input" : "{{ "general.validation.invalid_input"|trans }}"
+        }
+    </script>
     <script src="https://maps.googleapis.com/maps/api/js?key={{ googlemaps_key }}"></script>
     <script src="{{ asset('js/livemap.js') }}"></script>
     <script src="{{ asset("js/forms.js") }}"></script>

--- a/app/Resources/views/organisation/maakvereniging.html.twig
+++ b/app/Resources/views/organisation/maakvereniging.html.twig
@@ -37,6 +37,14 @@
 
 {% block javascripts %}
     {{ parent() }}
+
+    <script>
+        var translations = {
+            "not_valid" : "{{ "org.file.not_valid"|trans }}",
+            "too_large" : "{{ "org.file.too_large"|trans }}"
+        }
+    </script>
+
     <script src="https://maps.googleapis.com/maps/api/js?key={{ googlemaps_key }}"></script>
     <script src="{{ asset('js/livemap.js') }}"></script>
     <script src="{{ asset("js/forms.js") }}"></script>

--- a/app/Resources/views/person/edit_profile.html.twig
+++ b/app/Resources/views/person/edit_profile.html.twig
@@ -154,5 +154,5 @@
     <script src="https://maps.googleapis.com/maps/api/js?key={{ googlemaps_key }}"></script>
     <script src="{{ asset("js/forms.js") }}"></script>
     <script src="{{ asset("js/livemap.js") }}"></script>
-    <script src="{{ asset('js/upload.js') }}"></script>
+    {#<script src="{{ asset('js/upload.js') }}"></script>#}
 {% endblock %}

--- a/app/Resources/views/person/edit_profile.html.twig
+++ b/app/Resources/views/person/edit_profile.html.twig
@@ -154,5 +154,5 @@
     <script src="https://maps.googleapis.com/maps/api/js?key={{ googlemaps_key }}"></script>
     <script src="{{ asset("js/forms.js") }}"></script>
     <script src="{{ asset("js/livemap.js") }}"></script>
-    {#<script src="{{ asset('js/upload.js') }}"></script>#}
+    <script src="{{ asset('js/upload.js') }}"></script>
 {% endblock %}

--- a/app/Resources/views/person/edit_profile.html.twig
+++ b/app/Resources/views/person/edit_profile.html.twig
@@ -147,8 +147,9 @@
     {{ parent() }}
     <script>
         var translations = {
-            "not_valid" : "{{ "general.file.not_valid_image"|trans }}",
-            "too_large" : "{{ "general.file.too_large"|trans }}"
+            "not_valid" : "{{ "general.validation.not_valid_image"|trans }}",
+            "too_large" : "{{ "general.validation.too_large"|trans }}",
+            "invalid_input" : "{{ "general.validation.invalid_input"|trans }}"
         }
     </script>
     <script src="https://maps.googleapis.com/maps/api/js?key={{ googlemaps_key }}"></script>

--- a/app/Resources/views/person/edit_profile.html.twig
+++ b/app/Resources/views/person/edit_profile.html.twig
@@ -145,7 +145,14 @@
 
 {% block javascripts %}
     {{ parent() }}
+    <script>
+        var translations = {
+            "not_valid" : "{{ "general.file.not_valid_image"|trans }}",
+            "too_large" : "{{ "general.file.too_large"|trans }}"
+        }
+    </script>
     <script src="https://maps.googleapis.com/maps/api/js?key={{ googlemaps_key }}"></script>
     <script src="{{ asset("js/forms.js") }}"></script>
     <script src="{{ asset("js/livemap.js") }}"></script>
+    <script src="{{ asset('js/upload.js') }}"></script>
 {% endblock %}

--- a/app/Resources/views/person/vrijwilliger_worden.html.twig
+++ b/app/Resources/views/person/vrijwilliger_worden.html.twig
@@ -204,8 +204,9 @@
     {{ parent() }}
     <script>
         var translations = {
-            "not_valid" : "{{ "general.file.not_valid_image"|trans }}",
-            "too_large" : "{{ "general.file.too_large"|trans }}"
+            "not_valid" : "{{ "general.validation.not_valid_image"|trans }}",
+            "too_large" : "{{ "general.validation.too_large"|trans }}",
+            "invalid_input" : "{{ "general.validation.invalid_input"|trans }}"
         }
     </script>
 	<script src="https://maps.googleapis.com/maps/api/js?v=3&key={{ googlemaps_key }}"></script>

--- a/app/Resources/views/person/vrijwilliger_worden.html.twig
+++ b/app/Resources/views/person/vrijwilliger_worden.html.twig
@@ -202,9 +202,16 @@
 
 {% block javascripts %}
     {{ parent() }}
+    <script>
+        var translations = {
+            "not_valid" : "{{ "general.file.not_valid_image"|trans }}",
+            "too_large" : "{{ "general.file.too_large"|trans }}"
+        }
+    </script>
 	<script src="https://maps.googleapis.com/maps/api/js?v=3&key={{ googlemaps_key }}"></script>
     <script src="{{ asset("js/forms.js") }}"></script>
 	<script src="{{ asset('js/livemap.js') }}"></script>
 	<script src="{{ asset('js/passwordView.js') }}"></script>
+	<script src="{{ asset('js/upload.js') }}"></script>
 {% endblock %}
 

--- a/src/AppBundle/Entity/Form/EditPersonType.php
+++ b/src/AppBundle/Entity/Form/EditPersonType.php
@@ -37,6 +37,7 @@ class EditPersonType extends AbstractType
             ->add("avatarFile", FileType::class, array(
                 "label" => "person.label.avatar",
                 "required" => false,
+                "attr" => array("accept" => "images/png, images/jpg, images/jpeg")
             ))
             ->add("email", EmailType::class, array(
                 "label" => "person.label.email",

--- a/src/AppBundle/Entity/Form/EditPersonType.php
+++ b/src/AppBundle/Entity/Form/EditPersonType.php
@@ -37,7 +37,7 @@ class EditPersonType extends AbstractType
             ->add("avatarFile", FileType::class, array(
                 "label" => "person.label.avatar",
                 "required" => false,
-                "attr" => array("accept" => "images/png, images/jpg, images/jpeg")
+                "attr" => array("accept" => "image/png, image/jpg, image/jpeg")
             ))
             ->add("email", EmailType::class, array(
                 "label" => "person.label.email",

--- a/src/AppBundle/Entity/Form/OrganisationType.php
+++ b/src/AppBundle/Entity/Form/OrganisationType.php
@@ -39,7 +39,7 @@ class OrganisationType extends AbstractType
             ->add("logoFile", FileType::class, array(
                 "label" => "organisation.label.logo",
                 "required" => false,
-                "attr" => array("accept" => "images/png, images/jpg, images/jpeg")
+                "attr" => array("accept" => "image/png, image/jpg, image/jpeg")
             ))
             ->add("type", ChoiceType::class, array(
                 'label' => 'organisation.label.type',

--- a/src/AppBundle/Entity/Form/OrganisationType.php
+++ b/src/AppBundle/Entity/Form/OrganisationType.php
@@ -39,7 +39,7 @@ class OrganisationType extends AbstractType
             ->add("logoFile", FileType::class, array(
                 "label" => "organisation.label.logo",
                 "required" => false,
-                "attr" => array("accept" => "image/*")
+                "attr" => array("accept" => "images/png, images/jpg, images/jpeg")
             ))
             ->add("type", ChoiceType::class, array(
                 'label' => 'organisation.label.type',

--- a/src/AppBundle/Entity/Form/OrganisationType.php
+++ b/src/AppBundle/Entity/Form/OrganisationType.php
@@ -39,6 +39,7 @@ class OrganisationType extends AbstractType
             ->add("logoFile", FileType::class, array(
                 "label" => "organisation.label.logo",
                 "required" => false,
+                "attr" => array("accept" => "image/*")
             ))
             ->add("type", ChoiceType::class, array(
                 'label' => 'organisation.label.type',
@@ -69,7 +70,7 @@ class OrganisationType extends AbstractType
             ))
             ->add("submit", SubmitType::class, array(
                 "label" => "organisation.label.create",
-                "validation_groups" => array("firstStep"),
+                "validation_groups" => array("firstStep")
             ))
             ->add("street", TextType::class, array(
                 "label" => "organisation.label.street",

--- a/src/AppBundle/Entity/Form/PersonType.php
+++ b/src/AppBundle/Entity/Form/PersonType.php
@@ -37,7 +37,7 @@ class PersonType extends AbstractType
             ->add("avatarFile", FileType::class, array(
                 "label" => "person.label.avatar",
                 "required" => false,
-                "attr" => array("accept" => "images/png, images/jpg, images/jpeg")
+                "attr" => array("accept" => "image/png, image/jpg, image/jpeg")
             ))
             ->add("email", EmailType::class, array(
                 "label" => "person.label.email",

--- a/src/AppBundle/Entity/Form/PersonType.php
+++ b/src/AppBundle/Entity/Form/PersonType.php
@@ -37,6 +37,7 @@ class PersonType extends AbstractType
             ->add("avatarFile", FileType::class, array(
                 "label" => "person.label.avatar",
                 "required" => false,
+                "attr" => array("accept" => "images/png, images/jpg, images/jpeg")
             ))
             ->add("email", EmailType::class, array(
                 "label" => "person.label.email",

--- a/src/AppBundle/Entity/Organisation.php
+++ b/src/AppBundle/Entity/Organisation.php
@@ -189,9 +189,9 @@ class Organisation extends EntityBase
      * @Vich\UploadableField(mapping="organisation_logo", fileNameProperty="logoName")
      * @Assert\File(
      *      maxSize = "2M",
-     *      maxSizeMessage = "organisation.image_too_large",
-     *      mimeTypes = {"image/*"},
-     *      mimeTypesMessage = "organisation.image_not_valid",
+     *      maxSizeMessage = "file.image_too_large",
+     *      mimeTypes = {"image/png, image/jpg, image/jpeg"},
+     *      mimeTypesMessage = "file.image_not_valid",
      *      groups= "firstStep"
      * )
      */

--- a/src/AppBundle/Entity/Organisation.php
+++ b/src/AppBundle/Entity/Organisation.php
@@ -187,8 +187,13 @@ class Organisation extends EntityBase
      * NOTE: This is not a mapped field of entity metadata, just a simple property.
      *
      * @Vich\UploadableField(mapping="organisation_logo", fileNameProperty="logoName")
-     *
-     * @var File
+     * @Assert\File(
+     *      maxSize = "2M",
+     *      maxSizeMessage = "organisation.image_too_large",
+     *      mimeTypes = {"image/*"},
+     *      mimeTypesMessage = "organisation.image_not_valid",
+     *      groups= "firstStep"
+     * )
      */
     protected $logoFile;
 

--- a/src/AppBundle/Entity/Person.php
+++ b/src/AppBundle/Entity/Person.php
@@ -210,7 +210,7 @@ class Person extends OAuthUser implements UserInterface, \Serializable
      *      maxSizeMessage = "file.image_too_large",
      *      mimeTypes = {"image/png, image/jpg, image/jpeg"},
      *      mimeTypesMessage = "file.image_not_valid",
-     *      groups= "firstStep"
+     *      groups= {"firstStep", "edit"}
      * )
      */
     protected $avatarFile;

--- a/src/AppBundle/Entity/Person.php
+++ b/src/AppBundle/Entity/Person.php
@@ -205,6 +205,13 @@ class Person extends OAuthUser implements UserInterface, \Serializable
      * @Vich\UploadableField(mapping="person_avatar", fileNameProperty="avatarName")
      *
      * @var File
+     * * @Assert\File(
+     *      maxSize = "2M",
+     *      maxSizeMessage = "file.image_too_large",
+     *      mimeTypes = {"image/png, image/jpg, image/jpeg"},
+     *      mimeTypesMessage = "file.image_not_valid",
+     *      groups= "firstStep"
+     * )
      */
     protected $avatarFile;
 

--- a/web/js/upload.js
+++ b/web/js/upload.js
@@ -24,12 +24,12 @@
                         submitForm();
                         return;
                     default:
-                        alert("Gelieve een geldige afbeelding op te laden.");
+                        alert(translations.not_valid);
                         return;
                 }
 
                 if (blob.size > 2000000){
-                    alert("Gelieve een afbeelding op te laden die maximum 2MB groot is.");
+                    alert(translations.too_large);
                 } else {
                     submitForm();
                 }

--- a/web/js/upload.js
+++ b/web/js/upload.js
@@ -27,12 +27,12 @@
                         submitForm();
                         return;
                     default:
-                        alert(translations.not_valid);
+                        addErrorMessage(translations.not_valid);
                         return;
                 }
 
                 if (blob.size > 2000000){
-                    alert(translations.too_large);
+                    addErrorMessage(translations.too_large);
                 } else {
                     submitForm();
                 }
@@ -44,5 +44,10 @@
 
     function submitForm(){
         $usedForm.submit();
+    }
+
+    function addErrorMessage(message){
+        $("main").prepend('<div class="alert alert-danger">' + translations.invalid_input +'</div>');
+        $('input:file').parent().after('<div class="error"><ul><li>' + message + '</li></ul></div>');
     }
 })();

--- a/web/js/upload.js
+++ b/web/js/upload.js
@@ -1,12 +1,15 @@
 "use strict";
 (function () {
-    $('form[name="organisation"]').on("submit", function(event){
+    var $usedForm;
+
+    $('form').on("submit", function(event){
         event.preventDefault();
 
-        var blob = document.getElementById('organisation_logoFile').files[0];
+        $usedForm = this;
+        var blob = $('input:file')[0].files[0];
 
         if (typeof blob == "undefined"){
-            submitForm()
+            submitForm();
         } else {
             var fileReader = new FileReader();
             fileReader.onloadend = function (e) {
@@ -19,7 +22,7 @@
                 switch (header) {
                     case "89504e47": //image/png
                     case "ffd8ffe0": //image/jpeg
-                    case "ffd8ffe1": //image/
+                    case "ffd8ffe1": //image/jpeg
                     case "ffd8ffe2": //image/jpeg
                         submitForm();
                         return;
@@ -40,6 +43,6 @@
     });
 
     function submitForm(){
-        $('form[name="organisation"]')[0].submit();
+        $usedForm.submit();
     }
 })();

--- a/web/js/upload.js
+++ b/web/js/upload.js
@@ -1,0 +1,45 @@
+"use strict";
+(function () {
+    $('form[name="organisation"]').on("submit", function(event){
+        event.preventDefault();
+
+        var blob = document.getElementById('organisation_logoFile').files[0];
+
+        if (typeof blob == "undefined"){
+            submitForm()
+        } else {
+            var fileReader = new FileReader();
+            fileReader.onloadend = function (e) {
+                var arr = (new Uint8Array(e.target.result)).subarray(0, 4);
+                var header = "";
+                for (var i = 0; i < arr.length; i++) {
+                    header += arr[i].toString(16);
+                }
+
+                switch (header) {
+                    case "89504e47": //image/png
+                    case "ffd8ffe0": //image/jpeg
+                    case "ffd8ffe1": //image/
+                    case "ffd8ffe2": //image/jpeg
+                        submitForm();
+                        return;
+                    default:
+                        alert("Gelieve een geldige afbeelding op te laden.");
+                        return;
+                }
+
+                if (blob.size > 2000000){
+                    alert("Gelieve een afbeelding op te laden die maximum 2MB groot is.");
+                } else {
+                    submitForm();
+                }
+            };
+
+            fileReader.readAsArrayBuffer(blob);
+        }
+    });
+
+    function submitForm(){
+        $('form[name="organisation"]')[0].submit();
+    }
+})();


### PR DESCRIPTION
- Stap 1: Bij het openen van file explorer om een bestand te uploaden kan met standaard enkel .jp(e)g en .png bestanden zien. De gebruiker kan dit omzeilen door in de dropdownmenu "Alle bestanden" te selecteren i.p.v. "Aangepaste bestanden". Indien omzeilt en geen echte afbeelding of afbeelding groter dan 2MB --> Stap 2

- Stap 2: Bij het willen submitten met een geen geldige afbeelding of bestand die groter is dan 2MB wordt dit gecontroleerd via javascript en wordt er een gepaste message getoond. Indien javascript niet aan staat of moest de script aangepast zijn zodat dit niet client-sided wordt gecontroleerd --> Stap 3

- Stap 3: Indien de ongeldig of te groot bestand toch wordt gesubmit, wordt dit gecheckt door de server zelf. Indien het dus een ongeldig of te groot bestand is, toont de server een gepaste message en wordt de submit niet anvaard. 

_Info: de messages van de client en van de server zien er hetzelfde uit. Het enig verschil is dat de pagina gerefresht wordt als de validatie via de server is._

**Opmerking:** Als het bestand dat men wil uploaded groter is dan de ````max_upload_size```` of de hele POST-request groter is dan ````max_post_size```` komt er wel nog een 500 error. Deze kan niet opgevangen worden in de code voor zover ik weet. (Tenzij de 500 response globaal wordt opgevangen om een custom page te tonen natuurlijk)